### PR TITLE
fix: add titles to auto-complete components

### DIFF
--- a/src/auto-complete-multiple.tsx
+++ b/src/auto-complete-multiple.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
  * @param {any[]} rows - rows to be displayed in the dropdown
  * @param {any} value - the value of the selected item
  * @param {string} iconColor - the color of the down arrow icon
+ * @param {string} title - the title of the dropdown
  * @param {(data: any) => void} onChange - the function to be called when the value changes
  * @returns {React.FC<AktAutoCompleteMultipleProps>}
  * @example
@@ -19,6 +20,7 @@ import { useState } from 'react';
 interface AktAutoCompleteMultipleProps {
   rows: any[];
   value?: any;
+  title?: string;
   iconColor?: string;
   onChange: (data: any) => void;
 }
@@ -26,6 +28,7 @@ interface AktAutoCompleteMultipleProps {
 const AktAutoCompleteMultiple: React.FC<AktAutoCompleteMultipleProps> = ({
   rows,
   value,
+  title,
   iconColor = '#6b6b6b',
   onChange
 }: AktAutoCompleteMultipleProps) => {
@@ -41,6 +44,7 @@ const AktAutoCompleteMultiple: React.FC<AktAutoCompleteMultipleProps> = ({
       <Autocomplete
         multiple
         open={isOpen}
+        title={title}
         onBlur={() => setIsOpen(false)}
         options={rows}
         disableCloseOnSelect

--- a/src/auto-complete-virtualized/index.tsx
+++ b/src/auto-complete-virtualized/index.tsx
@@ -85,6 +85,7 @@ const ListboxComponent = React.forwardRef<
  * @param {any} value - value of the autocomplete
  * @param {string} valueKey - key of the value of the autocomplete
  * @param {string} labelKey - key of the label of the autocomplete
+ * @param {string} title - title of the autocomplete
  * @returns {React.FC<Props>}
  * @constructor
  * @component
@@ -99,6 +100,7 @@ interface AutoCompleteVirtualizedProps {
   value: any;
   valueKey?: string;
   labelKey: string;
+  title?: string;
 }
 
 const AutoCompleteVirtualized: React.FC<AutoCompleteVirtualizedProps> = ({
@@ -107,6 +109,7 @@ const AutoCompleteVirtualized: React.FC<AutoCompleteVirtualizedProps> = ({
   placeholder,
   value,
   labelKey,
+  title,
   valueKey
 }: AutoCompleteVirtualizedProps) => {
   labelKeyAux = labelKey;
@@ -114,6 +117,7 @@ const AutoCompleteVirtualized: React.FC<AutoCompleteVirtualizedProps> = ({
     <Autocomplete
       id="virtualize-autocomplete"
       disableListWrap
+      title={title}
       ListboxComponent={ListboxComponent}
       options={rows}
       data-testid="virtualize-autocomplete-test"

--- a/src/auto-complete.tsx
+++ b/src/auto-complete.tsx
@@ -18,6 +18,7 @@ import { useState } from 'react';
  * @param {string} groupFontSize - the font size of the group text element
  * @param {string} groupFontWeight - the font weight of the group text element
  * @param {string} iconColor - the color of the down arrow icon
+ * @param {string} title - the title of the dropdown
  * @param {(data: any) => void} onChange - the function to be called when the value changes
  * @returns {React.FC<AktAutoCompleteProps>}
  * @example
@@ -35,6 +36,7 @@ interface AktAutoCompleteProps {
   groupFontSize?: string;
   groupFontWeight?: string;
   iconColor?: string;
+  title?: string;
   onChange: (data: any) => void;
 }
 
@@ -49,6 +51,7 @@ const AktAutoComplete: React.FC<AktAutoCompleteProps> = ({
   groupFontSize = '1rem',
   groupFontWeight = 'bold',
   iconColor = '#6b6b6b',
+  title,
   onChange
 }: AktAutoCompleteProps) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -64,6 +67,7 @@ const AktAutoComplete: React.FC<AktAutoCompleteProps> = ({
         open={isOpen}
         onBlur={() => setIsOpen(false)}
         options={rows}
+        title={title}
         data-testid="auto-complete"
         getOptionLabel={(option) => option[textKey]}
         groupBy={groupKey ? (option) => String(option[groupKey]) : () => ''}


### PR DESCRIPTION
Resolves #NUMBER

**Description:**
_Introducing the ability to pass a "title" property to the autocomplete components._

**Type of change:**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

**Checklist:**

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
